### PR TITLE
This version of doc publisher & middleman are using a ruby version th…

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -83,7 +83,7 @@ jobs:
     - name: Output ownership report
       run: cd source/documentation && echo '${{needs.job1.outputs.output1}}' > repository_ownership.html.md.erb
     - name: Build
-      run: bundle exec middleman build --build-dir docs --relative-links
+      run: bundle exec middleman build --build-dir docs --relative-links 2>/dev/null
     - run: touch docs/.nojekyll
     - run: cd docs && echo 'docs.opg.service.justice.gov.uk' >CNAME
     - run: git config --global user.email "tools@digital.justice.gov.uk"

--- a/makefile
+++ b/makefile
@@ -13,7 +13,7 @@ build:
 		-v $$(pwd)/source:/app/source \
 		-v $$(pwd)/docs:/app/docs \
 		ministryofjustice/cloud-platform-tech-docs-publisher:1.1 \
-		bundle exec middleman build --build-dir docs --relative-links
+		bundle exec middleman build --build-dir docs --relative-links 2>/dev/null
 	touch docs/.nojekyll
 
 # Use this to run a local instance of the documentation site, while editing
@@ -25,4 +25,4 @@ preview:
 		-v $$(pwd)/source:/app/source \
 		-p 4567:4567 \
 		ministryofjustice/cloud-platform-tech-docs-publisher:1.1 \
-		bundle exec middleman serve
+		bundle exec middleman serve 2>/dev/null


### PR DESCRIPTION
…at generates a series of warning about URI.unescape being obsolete. As we dont control cloud platform image, will supress errors for now