### PR TITLE
Workflow changes

### DIFF
--- a/.github/workflows/ownership-report.yml
+++ b/.github/workflows/ownership-report.yml
@@ -1,0 +1,70 @@
+name: Generate Repository Ownership Artifact
+
+on:
+  schedule:
+    # Every Monday, at 12.15pm
+    - cron: '15 12 * * 1'
+
+jobs:
+  ownership_report:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.8]
+    steps:
+    - name: Get current date
+      id: date
+      run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+    - name: Checkout reporting repo
+      uses: actions/checkout@v2
+      with:
+        path: opg-repository-reports
+        repository: ministryofjustice/opg-repository-reporting
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        cd opg-repository-reports
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Output skeleton head
+      run: |
+        cd opg-repository-reports
+        echo "---
+        title: Repository Ownership
+        last_reviewed_on: ${{ steps.date.outputs.date }}
+        review_in: 3 months
+        ---
+
+        # <%= current_page.data.title %>
+
+        Listing of all our repositorys, team that owns them and their current status.
+
+        " > head.md
+    - name: Output skeleton tail
+      run: |
+        cd opg-repository-reports
+        echo "
+
+        ### Notes
+
+        This was generated via [this script](https://github.com/ministryofjustice/opg-repository-reporting/blob/main/ownership_report.py).
+
+        " > tail.md
+    - name: Run ownership report
+      env:
+        GITHUB_TOKEN: ${{ secrets.ORG_ACCESS_TOKEN }}
+      run: |
+        cd opg-repository-reports
+        python ./ownership_report.py --type md --filename ownership_report --exclude opg-webops
+    - name: Merge report and front matter files
+      run: |
+        cd opg-repository-reports
+        cat head.md ownership_report.md tail.md > repository_ownership.html.md.erb
+    - name: Capture the output of the report
+      uses: actions/upload-artifact@v2
+      with:
+        name: repository_ownership
+        path: opg-repository-reports/repository_ownership.html.md.erb

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,84 +8,21 @@ on:
       - "docs/**"
 
 jobs:
-  repository_reports:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [3.8]
-    steps:
-    - name: Get current date
-      id: date
-      run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
-    - name: Checkout reporting repo
-      uses: actions/checkout@v2
-      with:
-        path: opg-repository-reports
-        repository: ministryofjustice/opg-repository-reporting
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        cd opg-repository-reports
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-    - name: Output skeleton head
-      run: |
-        cd opg-repository-reports
-        echo "---
-        title: Repository Ownership
-        last_reviewed_on: ${{ steps.date.outputs.date }}
-        review_in: 3 months
-        ---
-
-        # <%= current_page.data.title %>
-
-        Listing of all our repositorys, team that owns them and their current status.
-
-        " > head.md
-    - name: Output skeleton tail
-      run: |
-        cd opg-repository-reports
-        echo "
-
-        ### Notes
-
-        The list of repositories was generated via [this script](https://github.com/ministryofjustice/opg-repository-reporting/blob/main/ownership_report.py).
-
-        " > tail.md
-    - name: Run ownership report
-      env:
-        GITHUB_TOKEN: ${{ secrets.ORG_ACCESS_TOKEN }}
-      run: |
-        cd opg-repository-reports
-        python ./ownership_report.py --type md --filename ownership_report --exclude opg-webops
-    - name: Merge report and front matter files
-      run: |
-        cd opg-repository-reports
-        cat head.md ownership_report.md tail.md > repository_ownership.html.md.erb
-    - name: Capture the output of the report
-      uses: actions/upload-artifact@v2
-      with:
-        name: repository_ownership
-        path: opg-repository-reports/repository_ownership.html.md.erb
-
   build_and_publish:
-    needs: repository_reports
     runs-on: ubuntu-latest
     container:
       image: ministryofjustice/tech-docs-github-pages-publisher:1.3
     steps:
-    - uses: actions/checkout@v2
-    - name: Download repository ownership report
+    - name: checkout
+      uses: actions/checkout@v2
+    - name: Download reports from artifacts
       uses: actions/download-artifact@v2
       with:
-        name: repository_ownership
-    - name: List files
-      run: ls -lart
-    - name: Move ownership report to correct location
-      run: mv -f repository_ownership.html.md.erb ./source/documentation/
+        path: artifacts
+    - name: List artifacts directory
+      run: ls -lart ./artifacts
+    - name: Move artifacts to source documents
+      run: mv -f artifacts/*.html.md.erb ./source/documentation/
     - name: Build
       run: bundle exec middleman build --build-dir docs --relative-links 2>/dev/null
     - run: touch docs/.nojekyll

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,9 @@ on:
       - "main"
     paths-ignore:
       - "docs/**"
+  schedule:
+    # Every Tuesday, at 9.15am
+    - cron: '15 9 * * 2'
 
 jobs:
   build_and_publish:

--- a/.github/workflows/tooling-report.yml
+++ b/.github/workflows/tooling-report.yml
@@ -1,0 +1,70 @@
+name: Generate Repository Tooling Artifact
+
+on:
+  schedule:
+    # Every Monday, at 1.15pm
+    - cron: '15 13 * * 1'
+
+jobs:
+  tooling_report:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.8]
+    steps:
+    - name: Get current date
+      id: date
+      run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+    - name: Checkout reporting repo
+      uses: actions/checkout@v2
+      with:
+        path: opg-repository-reports
+        repository: ministryofjustice/opg-repository-reporting
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        cd opg-repository-reports
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Output skeleton head
+      run: |
+        cd opg-repository-reports
+        echo "---
+        title: Repository Tooling
+        last_reviewed_on: ${{ steps.date.outputs.date }}
+        review_in: 3 months
+        ---
+
+        # <%= current_page.data.title %>
+
+        Tooling data found within our repositories.
+
+        " > head.md
+    - name: Output skeleton tail
+      run: |
+        cd opg-repository-reports
+        echo "
+
+        ### Notes
+
+        This was generated via [this script](https://github.com/ministryofjustice/opg-repository-reporting/blob/main/tooling_report.py).
+
+        " > tail.md
+    - name: Run tooling report
+      env:
+        GITHUB_TOKEN: ${{ secrets.ORG_ACCESS_TOKEN }}
+      run: |
+        cd opg-repository-reports
+        python ./tooling_report.py --type md --filename tooling_report
+    - name: Merge report and front matter files
+      run: |
+        cd opg-repository-reports
+        cat head.md tooling_report.md tail.md > repository_tooling.html.md.erb
+    - name: Capture the output of the report
+      uses: actions/upload-artifact@v2
+      with:
+        name: repository_tooling
+        path: opg-repository-reports/repository_tooling.html.md.erb

--- a/source/documentation/repository_tooling.html.md.erb
+++ b/source/documentation/repository_tooling.html.md.erb
@@ -1,0 +1,8 @@
+---
+title: Repository Tooling
+last_reviewed_on: 2021-04-19
+review_in: 3 months
+---
+
+
+# <%= current_page.data.title %>

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -45,8 +45,11 @@ New to the OPG team? [Read how to get started here](documentation/get_started)
 ## Ownership
 
 - [Repository Ownership](documentation/repository_ownership)
+- [Repository Tooling](documentation/repository_tooling)
 
-## [Architecture Decision Records](documentation/adrs.html)
+## Architecture Decision Records
+
+- [ADRs](documentation/adrs.html)
 
 ## Adding to the guide
 


### PR DESCRIPTION
Revert the default on push workflow to just run the doc generation, with the addition of pulling in all artifacts to the source documents and introduce a cron.

Add new cron based workflows for the ownership and tooling python scripts that run on monday that will generate and upload artifacts which are then downloaded by the publish workflow for generation