### PR TITLE
If the artifacts don’t exist (like at the moment), the step fails, so…

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,34 @@ jobs:
     container:
       image: ministryofjustice/tech-docs-github-pages-publisher:1.3
     steps:
+    - name: Get artifacts directly from the API
+      env:
+        GITHUB_TOKEN: ${{ secrets.ORG_ACCESS_TOKEN }}
+      run: |
+        repo="${{ github.repository }}"
+        token="${{ env.GITHUB_TOKEN }}"
+        declare -a artifacts=("repository_ownership" "repository_tooling")
+        mkdir -p ./artifacts/zip ./artifacts/erb
+        for artifact in "${artifacts[@]}"; do
+            echo "Getting all artifacts for this repo & looking for ${artifact}"
+            query="[ .artifacts[] | select(.name == \"${artifact}\").archive_download_url][0]"
+            # fetch the first url, trim " and add access token
+            artifact_url=$(curl --silent -H "Authorization: token ${token}" \
+                            https://api.github.com/repos/${repo}/actions/artifacts \
+                            | jq -c "${query}" \
+                            | tr -d \" )
+            len=${#artifact_url}
+            # download the zip, extract it and move
+            if [[ "${len}" -gt "5" ]]; then
+                echo "Artifact url: ${artifact_url}"
+                artifact_url="$(echo ${artifact_url} | sed s#api.#${token}@api.#g)"
+                echo "Downloading to local zip"
+                curl --silent -L "${artifact_url}" -o "./artifacts/zip/${artifact}.zip"
+                unzip -o "./artifacts/zip/${artifact}.zip" -d "./artifacts/erb/"
+            else
+                echo "No artifact found for ${artifact}"
+            fi
+        done
     - name: checkout
       uses: actions/checkout@v2
     - name: Download reports from artifacts
@@ -27,7 +55,7 @@ jobs:
         ls -lart
         if [ -d artifacts ]; then
           ls -lart artifacts*
-          find ./artifacts -type f -name "*.html.md.erb" -exec mv {} ./source/documentation \;
+          find ./artifacts -type f -name "*.erb" -exec mv {} ./source/documentation \;
         fi
     - name: Build
       run: bundle exec middleman build --build-dir docs --relative-links 2>/dev/null

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,10 +22,13 @@ jobs:
       uses: actions/download-artifact@v2
       with:
         path: artifacts
-    - name: List artifacts directory
-      run: ls -lart ./artifacts
-    - name: Move artifacts to source documents
-      run: mv -f artifacts/*.html.md.erb ./source/documentation/
+    - name: List and move artifacts if they exist
+      run: |
+        ls -lart
+        if [ -d artifacts ]; then
+          ls -lart artifacts*
+          find ./artifacts -type f -name "*.html.md.erb" -exec mv {} ./source/documentation \;
+        fi
     - name: Build
       run: bundle exec middleman build --build-dir docs --relative-links 2>/dev/null
     - run: touch docs/.nojekyll


### PR DESCRIPTION
… update the step to check the download worked and move all files with a recursive find