### PR TITLE
Add note on channel

### DIFF
--- a/source/documentation/incidents/process.html.md.erb
+++ b/source/documentation/incidents/process.html.md.erb
@@ -46,7 +46,7 @@ The slack bot will automatically post a message into the `#opg-incidents` channe
 
 As soon as the tool has posted a message into `#opg-incidents` you should do these steps immediatly
 
-1. Hit the create communtications channel button in the message.
+1. Hit the create communtications channel button in the message (only available for active incidents).
 2. Page the on-call incident lead.
 
 These steps should be done


### PR DESCRIPTION
Make a channel option only available for active incidents, not historical ones