### PR TITLE
Fix link colour issue in opg-tag-list

### DIFF
--- a/source/stylesheets/_opg-tag-list.css.scss
+++ b/source/stylesheets/_opg-tag-list.css.scss
@@ -1,0 +1,37 @@
+@mixin whitelink {
+  &:visited,
+  &:link {
+    color: #ffffff;
+  }
+}
+@mixin bluelink {
+  &:visited,
+  &:link {
+    color: #4c2c92;
+  }
+}
+.opg-tag-list {
+  .opg-tag {
+    margin-bottom: 0.5rem;
+    margin-right: 0.5rem;
+    font-size: 0.8rem;
+
+    &--not-owned {
+      @include whitelink;
+      &:before {
+        content: "\2718";
+        color: #d4351c;
+      }
+    }
+
+    &--owner {
+      @include whitelink;
+    }
+  }
+
+  .govuk-tag {
+    &--grey {
+      @include bluelink;
+    }
+  }
+}

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -1,28 +1,12 @@
 @import "govuk_tech_docs";
+@import "_opg-tag-list.css.scss";
 
-
-
-.opg-warning{
-    padding:0.5rem;
-    border: 5px solid #d4351c
-}
-.opg-tag{
-    margin-bottom:0.5rem;
-    margin-right:0.5rem;
-    font-size:0.8rem;
+.opg-warning {
+  padding: 0.5rem;
+  border: 5px solid #d4351c;
 }
 
-.opg-tag.opg-tag--not-owned::before{
-    content: "\2718";
-    color: #d4351c;
-}
-
-
-.opg-tag-list a.opg-tag--owner:visited{
-    color:white;
-}
-
-.opg-team{
-    padding-bottom: 0.5rem;
-    border-bottom:3px solid;
+.opg-team {
+  padding-bottom: 0.5rem;
+  border-bottom: 3px solid;
 }


### PR DESCRIPTION
* Moves `opg-tag-list` to its own file
* Convert to SASS format
* Override colours correctly