### PR TITLE
Remove refund dev/preprod roles

### DIFF
--- a/source/documentation/aws_roles.html.md.erb
+++ b/source/documentation/aws_roles.html.md.erb
@@ -115,14 +115,6 @@ role_arn=arn:aws:iam::980242665824:role/operator
 Viewer Roles
 
 ```bash
-[profile moj-refunds-dev]
-region=eu-west-1
-role_arn=arn:aws:iam::936779158973:role/viewer
-
-[profile moj-refunds-preprod]
-region=eu-west-1
-role_arn=arn:aws:iam::764856231715:role/viewer
-
 [profile moj-refunds-prod]
 region=eu-west-1
 role_arn=arn:aws:iam::805626386523:role/viewer
@@ -132,14 +124,6 @@ role_arn=arn:aws:iam::805626386523:role/viewer
 Operator Roles
 
 ```bash
-[profile moj-refunds-dev]
-region=eu-west-1
-role_arn=arn:aws:iam::936779158973:role/operator
-
-[profile moj-refunds-preprod]
-region=eu-west-1
-role_arn=arn:aws:iam::764856231715:role/operator
-
 [profile moj-refunds-prod]
 region=eu-west-1
 role_arn=arn:aws:iam::805626386523:role/operator


### PR DESCRIPTION
The underlying accounts are no longer used for Refunds