### PR TITLE
Add co-owner tag class

### DIFF
--- a/source/stylesheets/_opg-tag-list.css.scss
+++ b/source/stylesheets/_opg-tag-list.css.scss
@@ -27,6 +27,11 @@
     &--owner {
       @include whitelink;
     }
+
+    &--co-owner {
+      @include whitelink;
+      background-color: #6f72af;
+    }
   }
 
   .govuk-tag {


### PR DESCRIPTION
So that the team metadata report can differentiate between solo-owned and co-owned repos

Result, with ministryofjustice/opg-repository-reporting#108:

![image](https://github.com/ministryofjustice/opg-technical-guidance/assets/100852/4312ce60-5b5a-4aa1-ada3-b6ed1c63b978)
