### PR TITLE
Add log structure ADR

### DIFF
--- a/source/documentation/adrs.html.md.erb
+++ b/source/documentation/adrs.html.md.erb
@@ -19,6 +19,7 @@ To understand why we are recording decisions and how we are doing it, please see
 | ✅ | ADR-006 | [Migrate to Github Actions instead of CircleCI](adrs/adr-006.html) |
 | ✅ | ADR-007 | [Healthcheck Definitions](adrs/adr-007.html) |
 | ✅ | ADR-008 | [Deployment environments](adrs/adr-008.html) |
+| 🤔 | ADR-009 | [Log structure](adrs/adr-009.html) |
 
 ### Statuses:
 

--- a/source/documentation/adrs/adr-009.html.md.erb
+++ b/source/documentation/adrs/adr-009.html.md.erb
@@ -1,0 +1,60 @@
+---
+title: ADR-009 Log structure
+last_reviewed_on: 2024-02-09
+review_in: 12 months
+---
+# <%= current_page.data.title %>
+
+Date: 14-02-2024
+
+## Status
+
+🤔 Proposed
+
+## Context
+
+Regardless of platform or language, our services write logging information to the output stream. However, this logging information is inconsitently structured. This leads to a few problems:
+
+1. It is hard to interpret logs under standard operation, as logs from different containers with different structures are interspersed
+2. During an incident, it is hard to find related logs as the inconsistent structures require separate queries
+3. Our log-based alarms are complex to write and update as they have to query several different structures
+
+## Decision
+
+We will define a standard logging structure that all teams will use. Teams are welcome to expand on the structure by adding extra fields, but must include all required fields in each log message and must ensure not to use reserved fields for anything other than their defined usage.
+
+All logs must be formatted as JSON objects.
+
+An example of a minimal log message:
+
+```json
+{"timestamp": "2024-02-14T12:34:23Z", "service": "opg-refunds", "level": "CRITICAL", "msg": "Null pointer exception"}
+```
+
+An example of a more complex log message:
+
+```json
+{"timestamp": "2024-02-14T13:39:01Z", "service": "opg-refunds/front", "level": "INFO", "msg": "User authentication failed", "trace_id": "1-581cf771-a006649127e371903a2de979", "request": {"method": "GET", "path": "/auth/login"}}
+```
+
+### Required fields
+
+`timestamp` must be an RFC3339-formatted date/time.
+
+`service` must a string denoting the service where the log message originated.
+
+`level` must be an RFC5424-defined log level in uppercase: `EMERGENCY`, `ALERT`, `CRITICAL`, `ERROR`, `WARNING`, `NOTICE`, `INFO`, `DEBUG`. Services don't need to use every log level, but alarms and stored queries should account for them all.
+
+`msg` is the free form message.
+
+### Reserved fields
+
+`trace_id`, if provided, must be a string containing the AWS X-Ray trace ID of the orgininating request.
+
+`request`, if provided, must be an object containing a `method` property containing the request's HTTP method, and a `path` property containing the requested path
+
+## Consequences
+
+Reading logs interspersed between different services and containers will be easier as they all follow the same structure. We will be able to write common queries and alarms that work across all of our services.
+
+Each team will need to review their current logging instrumentation to ensure it matches this structure.

--- a/source/documentation/adrs/adr-009.html.md.erb
+++ b/source/documentation/adrs/adr-009.html.md.erb
@@ -28,14 +28,14 @@ All logs must be formatted as JSON objects.
 An example of a minimal log message:
 
 ```json
-{"timestamp": "2024-02-14T12:34:23Z", "level": "CRITICAL", "msg": "Null pointer exception"}
+{"time": "2024-02-14T12:34:23Z", "level": "CRITICAL", "msg": "Null pointer exception"}
 ```
 
 An example of a more complex log message:
 
 ```json
 {
-  "timestamp": "2024-02-14T13:39:01Z",
+  "time": "2024-02-14T13:39:01Z",
   "level": "INFO",
   "msg": "User permissions updated",
   "trace_id": "1-581cf771-a006649127e371903a2de979",
@@ -49,7 +49,7 @@ As well as the required and reserved fields below, log messages can include any 
 
 ### Required fields
 
-`timestamp` must be an RFC3339-formatted date/time.
+`time` must be an RFC3339-formatted date/time.
 
 `level` must be an RFC5424-defined log level in uppercase: `EMERGENCY`, `ALERT`, `CRITICAL`, `ERROR`, `WARNING`, `NOTICE`, `INFO`, `DEBUG`. Services don't need to use every log level, but alarms and stored queries should account for them all.
 

--- a/source/documentation/adrs/adr-009.html.md.erb
+++ b/source/documentation/adrs/adr-009.html.md.erb
@@ -38,6 +38,7 @@ An example of a more complex log message:
   "time": "2024-02-14T13:39:01Z",
   "level": "INFO",
   "msg": "User permissions updated",
+  "service_name": "",
   "trace_id": "1-581cf771-a006649127e371903a2de979",
   "request": { "method": "PUT", "path": "/user/133/permissions" },
   "location": { "file": "pages/user/edit_permission.go", "line": 156 },
@@ -51,9 +52,11 @@ As well as the required and reserved fields below, log messages can include any 
 
 `time` must be an RFC3339-formatted date/time.
 
-`level` must be an RFC5424-defined log level in uppercase: `EMERGENCY`, `ALERT`, `CRITICAL`, `ERROR`, `WARNING`, `NOTICE`, `INFO`, `DEBUG`. Services don't need to use every log level, but alarms and stored queries should account for them all.
+`level` must be an RFC5424-defined log level in uppercase: `EMERGENCY`, `ALERT`, `CRITICAL`, `ERROR`, `WARNING`, `NOTICE`, `INFO`, `DEBUG`. Services don't need to use every log level, but alarms and stored queries should account for them all. Whilst all log levels can be used in code, the minimum logging level should be `INFO` in non-dev environments.
 
 `msg` is the free form message.
+
+`service_name` is the name of the container or lambda outputting the log.
 
 ### Reserved fields
 

--- a/source/documentation/adrs/adr-009.html.md.erb
+++ b/source/documentation/adrs/adr-009.html.md.erb
@@ -34,8 +34,18 @@ An example of a minimal log message:
 An example of a more complex log message:
 
 ```json
-{"timestamp": "2024-02-14T13:39:01Z", "level": "INFO", "msg": "User authentication failed", "trace_id": "1-581cf771-a006649127e371903a2de979", "request": {"method": "GET", "path": "/auth/login"}}
+{
+  "timestamp": "2024-02-14T13:39:01Z",
+  "level": "INFO",
+  "msg": "User permissions updated",
+  "trace_id": "1-581cf771-a006649127e371903a2de979",
+  "request": { "method": "PUT", "path": "/user/133/permissions" },
+  "location": { "file": "pages/user/edit_permission.go", "line": 156 },
+  "actor_id": 48
+}
 ```
+
+As well as the required and reserved fields below, log messages can include any other fields (such as "location" and "actor_id" above).
 
 ### Required fields
 

--- a/source/documentation/adrs/adr-009.html.md.erb
+++ b/source/documentation/adrs/adr-009.html.md.erb
@@ -59,8 +59,6 @@ As well as the required and reserved fields below, log messages can include any 
 
 `request`, if provided, must be an object containing a `method` property of the request's HTTP method, and a `path` property of the requested path. Additional properties are permitted.
 
-`source`, if provided, must be a string that differntiates which resource the log came from. It should be set consistently at the resource level (e.g. all logs from one ECS container should have the same source).
-
 `trace_id`, if provided, must be a string containing the AWS X-Ray trace ID of the orgininating request.
 
 ## Consequences

--- a/source/documentation/adrs/adr-009.html.md.erb
+++ b/source/documentation/adrs/adr-009.html.md.erb
@@ -28,20 +28,18 @@ All logs must be formatted as JSON objects.
 An example of a minimal log message:
 
 ```json
-{"timestamp": "2024-02-14T12:34:23Z", "service": "opg-refunds", "level": "CRITICAL", "msg": "Null pointer exception"}
+{"timestamp": "2024-02-14T12:34:23Z", "level": "CRITICAL", "msg": "Null pointer exception"}
 ```
 
 An example of a more complex log message:
 
 ```json
-{"timestamp": "2024-02-14T13:39:01Z", "service": "opg-refunds/front", "level": "INFO", "msg": "User authentication failed", "trace_id": "1-581cf771-a006649127e371903a2de979", "request": {"method": "GET", "path": "/auth/login"}}
+{"timestamp": "2024-02-14T13:39:01Z", "level": "INFO", "msg": "User authentication failed", "trace_id": "1-581cf771-a006649127e371903a2de979", "request": {"method": "GET", "path": "/auth/login"}}
 ```
 
 ### Required fields
 
 `timestamp` must be an RFC3339-formatted date/time.
-
-`service` must a string denoting the service where the log message originated.
 
 `level` must be an RFC5424-defined log level in uppercase: `EMERGENCY`, `ALERT`, `CRITICAL`, `ERROR`, `WARNING`, `NOTICE`, `INFO`, `DEBUG`. Services don't need to use every log level, but alarms and stored queries should account for them all.
 
@@ -49,9 +47,11 @@ An example of a more complex log message:
 
 ### Reserved fields
 
-`trace_id`, if provided, must be a string containing the AWS X-Ray trace ID of the orgininating request.
+`request`, if provided, must be an object containing a `method` property of the request's HTTP method, and a `path` property of the requested path. Additional properties are permitted.
 
-`request`, if provided, must be an object containing a `method` property containing the request's HTTP method, and a `path` property containing the requested path
+`source`, if provided, must be a string that differntiates which resource the log came from. It should be set consistently at the resource level (e.g. all logs from one ECS container should have the same source).
+
+`trace_id`, if provided, must be a string containing the AWS X-Ray trace ID of the orgininating request.
 
 ## Consequences
 


### PR DESCRIPTION
Reasoning, a lot of which refers to [RFC5424](https://datatracker.ietf.org/doc/html/rfc5424):

- JSON format: Already an accepted standard in OPG
- `time` field name: clear, concise and matches slog default (slog being the only standard library structured logging tool in our supported languages)
- `time` in RFC3339 format: both computer and human readable
- `level` field name: clear, widely used and matches RFC5424 terminology
- `level` as string: both computer and human readable
- `level` as uppercase: good to be consistent one way, default in slog and monolog
- `level` values: matches RFC5424 and [PSR-3](https://www.php-fig.org/psr/psr-3/), slog uses a subset by default. Some libraries will allow devs to use all levels, so I think it's sensible to support them all even if we generally only use some.
- `msg` field name: matches RFC5424 and slog default
- `request` field name: standard namng
- `request` includes method and path: these are reliably available in all context/technologies
- `request` allows additional fields: some teams may want to log content length, client IPs or other things
- `trace_id` field name: standard naming used by X-Ray and OpenTelemetry

[PSR-3]: https://dsdmoj.atlassian.net/browse/PSR-3?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ