### PR TITLE
Add new report to the publishing

### DIFF
--- a/.github/actions/find-delete/action.yml
+++ b/.github/actions/find-delete/action.yml
@@ -1,0 +1,52 @@
+name: "Find and Delete"
+description: "Delete using find"
+
+inputs:
+  base_dir:
+    description: "base directory"
+  exclude:
+    description: "exclude this path"
+  type:
+    description: "directory or file"
+  confirm:
+    description: "really run the delete"
+
+runs:
+  using: "composite"
+  steps:
+    - name: "Before"
+      working-directory: ${{ inputs.base_dir}}
+      shell: bash
+      run: ls -lart
+    - name: "Deleting directories"
+      if: ${{ contains(inputs.type, 'directory') }}
+      working-directory: ${{ inputs.base_dir}}
+      shell: bash
+      env:
+        confirmed: ${{ inputs.confirm }}
+      run: |
+        find . -type d -maxdepth 1 ! -path "." ! -path ".." ! -path "${{ inputs.exclude }}" | while read thisdir; do
+          echo -e "deleting dir: ${thisdir}"  
+          if [ "${{env.confirmed}}" == "y" ]; then
+            rm -Rf ${thisdir}
+          fi          
+        done
+    - name: "Deleting files"
+      if: ${{ contains(inputs.type, 'file') }}
+      working-directory: ${{ inputs.base_dir}}
+      shell: bash
+      env:
+        confirmed: ${{ inputs.confirm }}
+      run: |
+        find . -type f -maxdepth 1 ! -path "." ! -path ".." ! -path "${{ inputs.exclude }}" | while read thisfile; do
+          echo -e "deleting file: ${thisfile}"  
+          if [ "${{env.confirmed}}" == "y" ]; then
+            rm -Rf ${thisfile}
+          fi          
+        done
+    - name: "After"
+      working-directory: ${{ inputs.base_dir}}
+      shell: bash
+      run: ls -lart
+
+

--- a/.github/actions/find-delete/action.yml
+++ b/.github/actions/find-delete/action.yml
@@ -17,7 +17,9 @@ runs:
     - name: "Before"
       working-directory: ${{ inputs.base_dir}}
       shell: bash
-      run: ls -lart
+      run: |
+        echo -e "Before:"
+        ls -lart
     - name: "Deleting directories"
       if: ${{ contains(inputs.type, 'directory') }}
       working-directory: ${{ inputs.base_dir}}
@@ -47,6 +49,8 @@ runs:
     - name: "After"
       working-directory: ${{ inputs.base_dir}}
       shell: bash
-      run: ls -lart
+      run: |
+        echo -e "After:"
+        ls -lart
 
 

--- a/.github/actions/find-delete/action.yml
+++ b/.github/actions/find-delete/action.yml
@@ -8,7 +8,7 @@ inputs:
     description: "exclude this path"
   type:
     description: "directory or file"
-  confirm:
+  confirm_delete:
     description: "really run the delete"
 
 runs:
@@ -23,11 +23,11 @@ runs:
       working-directory: ${{ inputs.base_dir}}
       shell: bash
       env:
-        confirmed: ${{ inputs.confirm }}
+        confirmed: ${{ inputs.confirm_delete }}
       run: |
         find . -type d -maxdepth 1 ! -path "." ! -path ".." ! -path "${{ inputs.exclude }}" | while read thisdir; do
           echo -e "deleting dir: ${thisdir}"  
-          if [ "${{env.confirmed}}" == "y" ]; then
+          if [ "${{ env.confirmed }}" == "true" ]; then
             rm -Rf ${thisdir}
           fi          
         done
@@ -36,11 +36,11 @@ runs:
       working-directory: ${{ inputs.base_dir}}
       shell: bash
       env:
-        confirmed: ${{ inputs.confirm }}
+        confirmed: ${{ inputs.confirm_delete }}
       run: |
         find . -type f -maxdepth 1 ! -path "." ! -path ".." ! -path "${{ inputs.exclude }}" | while read thisfile; do
           echo -e "deleting file: ${thisfile}"  
-          if [ "${{env.confirmed}}" == "y" ]; then
+          if [ "${{ env.confirmed }}" == "true" ]; then
             rm -Rf ${thisfile}
           fi          
         done

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,9 @@
 name: Publish Docs
 
 on:
+  pull_request:
+    branches: 
+      - "main"
   push:
     branches:
       - "main"
@@ -13,6 +16,8 @@ on:
 jobs:
     
     build_and_publish:
+      env:
+        exclude_from_docs_delete: "./documention/reports/service-uptime"
       name: Build and Publish
       runs-on: ubuntu-latest
       steps:
@@ -37,6 +42,13 @@ jobs:
           workflow_name: 'reports-repository-standards.yml'
           download_to: ${{ github.workspace }}/_reports_repository_standards
           move_to: ${{ github.workspace }}/source/documentation/reports
+      - name: "[Report] Service Uptime"
+        uses: './.github/actions/artifact-download'
+        with:
+          artifact_name: 'service-uptime'
+          workflow_name: 'reports-service-uptime.yml'
+          download_to: ${{ github.workspace }}/_reports_service_uptime
+          move_to: ${{ github.workspace }}/source/documentation/reports
       ############
       # Build steps
       ############
@@ -51,9 +63,9 @@ jobs:
       - name: "Checkout to gh-pages and move built files back"
         run: |
           git checkout -f gh-pages
-          rm -Rf ./source/
-          rm -Rf ./docs          
-          mv ../docs ./
+          rm -Rf ./source/          
+          find ./docs -type d ! -name "${{ env.exclude_from_docs_delete }}" -delete
+          cp -RF ../docs/ ./          
       - name: "Add version and CNAME file"
         run: |
           echo "${GITHUB_SHA}" > ./docs/version.txt

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -76,7 +76,7 @@ jobs:
         uses: './.github/actions/find-delete'
         with:
           base_dir: ${{ github.workspace }}/docs/documentation
-          exclude: './reports/'
+          exclude: './reports'
           type: 'directory file'
 
       

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,12 +62,14 @@ jobs:
           mv ./docs ../
       - name: "Checkout to gh-pages and move built files back"
         run: |
-          git checkout -f gh-pages          
-          ls -lart    
+          git checkout -f gh-pages                    
           rm -Rf ./source/
-          
-          find ./docs -type d ! -name "${{ env.exclude_from_docs_delete }}" -exec rm -rf "{}" \;
+          cd ./docs
+          pwd
           ls -lart
+          find . -type d ! -name "${{ env.exclude_from_docs_delete }}" -exec rm -rf "{}" \;
+          ls -lart
+          cd ../
           cp -RT ../docs/ ./          
       - name: "Add version and CNAME file"
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,10 +54,11 @@ jobs:
         run: |
           git config --global user.email "tools@digital.justice.gov.uk"
           git config --global user.name "Github Action"
-      - name: "Build and move output"
+      - name: "Build and move output and github directory"
         run: |
           make build
           mv ./docs ../
+          # move this because we use some local actions and the checkout removes that folder
           mv ./.github/ ../
       - name: "Checkout to gh-pages and clean untracked files"
         run: |
@@ -78,6 +79,7 @@ jobs:
           base_dir: ${{ github.workspace }}/docs/documentation
           exclude: './reports'
           type: 'directory file'
+          confirm_delete: true
 
       
       - name: "Move built files over"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -80,6 +80,13 @@ jobs:
           exclude: './reports'
           type: 'directory file'
           confirm_delete: true
+      - name: "Remove other directories from ./docs/documentation/reports, excluding ./service-uptime"
+        uses: './.github/actions/find-delete'
+        with:
+          base_dir: ${{ github.workspace }}/docs/documentation/reports
+          exclude: './service-uptime'
+          type: 'directory file'
+          confirm_delete: true
 
       - name: "Move built files over"
         run : |  
@@ -90,9 +97,10 @@ jobs:
           ls -lart ./
           ls -lartR ./docs/
       - name: "Add version and CNAME file"
-        run: |
+        run: |          
           echo "${GITHUB_SHA}" > ./docs/version.txt
           echo 'docs.opg.service.justice.gov.uk' > ./docs/CNAME
+          echo "" > ./docs/.gitkeep
           git status
       - name: "Git commit"
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,25 +62,26 @@ jobs:
         run: git checkout -f gh-pages                    
       - name: "Remove ./source/"
         run: rm -Rf ./source/
-      - name: "Remove top level directories from ./docs"
-        working-directory: ${{ github.workspace }}/docs
-        run: |          
-          ls -lart
-          # delete all top level folders except for documentation
-          find . -type d -maxdepth 1 ! -path "." ! -path ".." ! -path "./documentation" | while read thisdir; do
-            echo -e "deleting dir: ${thisdir}"  
-            rm -Rf ${thisdir}          
-          done
-          ls -lart
-      - name: "Remove top level files from ./docs"
-        working-directory: ${{ github.workspace }}/docs
-        run: |
-          ls -lart
-          find . -type f -maxdepth 1 ! -path "." ! -path ".." ! -path "./documentation" | while read thisfile; do
-            echo -e "deleting file: ${thisfile}"  
-            # rm -Rf ${thisdir}          
-          done
-          ls -lart
+      - name: "Remove top level directories and files from ./docs"
+        uses: './.github/actions/find-delete'
+        with:
+          base_dir: ${{ github.workspace }}/docs
+          exclude: './documentation'
+          type: 'directory file'
+      
+      # - name: "Remove other directories from ./docs/documentation, leaving ./reports/ only"
+      #   working-directory: ${{ github.workspace }}/docs/documentation
+      #   run: | 
+      #     echo -e "Before:"         
+      #     ls -lart
+      #     # delete all top level folders except for documentation
+      #     find . -type d -maxdepth 1 ! -path "." ! -path ".." ! -path "./reports" | while read thisdir; do
+      #       echo -e "deleting dir: ${thisdir}"  
+      #       #rm -Rf ${thisdir}          
+      #     done
+      #     echo -e "After:"         
+      #     ls -lart
+      
       - name: "Move built files over"
         run : |          
           cp -RT ../docs/ ./          

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -67,8 +67,8 @@ jobs:
           cd ./docs/
           ls -lart
           # delete all top level folders that isn't reports 
-          find . -type d -maxdepth 1 ! -name "${{ env.reports_root }}" -not -path '.' | while read thisdir; do
-            echo -e "${thisdir}"
+          find . -type d -maxdepth 1 -not -path ./${{ env.reports_root }}/* | while read thisdir; do
+            echo -e "dir: ${thisdir}"
             rm -Rf ./${thisdir}
           done
           

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -81,14 +81,13 @@ jobs:
           type: 'directory file'
           confirm_delete: true
 
-      
       - name: "Move built files over"
         run : |  
           echo -e "Current:"        
           ls -lartR ./docs/
           cp -rf ../docs/* ./docs/
           echo -e "After:"
-          la -lart ./
+          ls -lart ./
           ls -lartR ./docs/
       - name: "Add version and CNAME file"
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -108,10 +108,10 @@ jobs:
           ls -lart ./
           ls -lartR ./docs/
       - name: "Add version and CNAME file"
-        run: |          
+        run: |
           echo "${GITHUB_SHA}" > ./docs/version.txt
           echo 'docs.opg.service.justice.gov.uk' > ./docs/CNAME
-          echo "" > ./docs/.gitkeep
+          touch ./docs/.gitkeep
           rm -Rf ./.github
           git status
       - name: "Git commit"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,7 +59,6 @@ jobs:
           make build
           mv ./docs ../
       - name: "Checkout to gh-pages and move built files back"
-        env:
         run: |
           git checkout -f gh-pages                    
           rm -Rf ./source/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -112,6 +112,7 @@ jobs:
           echo "${GITHUB_SHA}" > ./docs/version.txt
           echo 'docs.opg.service.justice.gov.uk' > ./docs/CNAME
           echo "" > ./docs/.gitkeep
+          rm -Rf ./.github
           git status
       - name: "Git commit"
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -86,8 +86,9 @@ jobs:
         run : |  
           echo -e "Current:"        
           ls -lartR ./docs/
-          cp -RT ../docs ./        
-          echo -e "After:"          
+          cp -rf ../docs/* ./docs/
+          echo -e "After:"
+          la -lart ./
           ls -lartR ./docs/
       - name: "Add version and CNAME file"
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,10 +58,13 @@ jobs:
         run: |
           make build
           mv ./docs ../
-      - name: "Checkout to gh-pages"
-        run: git checkout -f gh-pages                    
-      - name: "Remove ./source/"
-        run: rm -Rf ./source/
+          mv ./.github/ ../
+      - name: "Checkout to gh-pages and clean untracked files"
+        run: |
+          git checkout -f gh-pages                    
+          git clean -fd
+      - name: "Move gh folder back"
+        run: mv ../.github ./
       - name: "Remove top level directories and files from ./docs"
         uses: './.github/actions/find-delete'
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,9 +62,12 @@ jobs:
           mv ./docs ../
       - name: "Checkout to gh-pages and move built files back"
         run: |
-          git checkout -f gh-pages
-          rm -Rf ./source/          
+          git checkout -f gh-pages          
+          ls -lart    
+          rm -Rf ./source/
+          
           find ./docs -type d ! -name "${{ env.exclude_from_docs_delete }}" -exec rm -rf "{}" \;
+          ls -lart
           cp -RT ../docs/ ./          
       - name: "Add version and CNAME file"
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -66,6 +66,11 @@ jobs:
           git clean -fd
       - name: "Move gh folder back"
         run: mv ../.github ./
+      ############
+      # Remove existing folders from gh-pages expect service-uptime reports
+      # Uptime reports use artifacts and data from aws with limited lifetimes, 
+      # so instead of removing them from repo we'll keep the older data here
+      ############
       - name: "Remove top level directories and files from ./docs, excluding ./documentation"
         uses: './.github/actions/find-delete'
         with:
@@ -87,12 +92,18 @@ jobs:
           exclude: './service-uptime'
           type: 'directory file'
           confirm_delete: true
-
+      ############
+      # Copy over the generated ./docs folder 
+      ############
       - name: "Move built files over"
         run : |  
+          echo -e "===="
           echo -e "Current:"        
           ls -lartR ./docs/
+
           cp -rf ../docs/* ./docs/
+
+          echo -e "===="
           echo -e "After:"
           ls -lart ./
           ls -lartR ./docs/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,8 +16,6 @@ on:
 jobs:
     
     build_and_publish:
-      env:
-        exclude_from_docs_delete: "./documention/reports/service-uptime"
       name: Build and Publish
       runs-on: ubuntu-latest
       steps:
@@ -64,15 +62,13 @@ jobs:
         run: |
           git checkout -f gh-pages                    
           rm -Rf ./source/
-          cd ./docs
-          find . -type d | while read -r i; do
-            echo -e "${i}";
-            if [ "${i}" != "${{ env.exclude_from_docs_delete}}" ]; then
-              echo -e "delete... "
-            fi
-          done
-          cd ../
+          cd ./docs/
+          # delete all top level folders that isn't reports -exec rm -rf "{}" \;
+          find . -type d -maxdepth 1 ! -name "./documention/" -printf '%f\n'
+          
+          ls -lart
 
+          cd ../
           cp -RT ../docs/ ./          
       - name: "Add version and CNAME file"
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -64,9 +64,15 @@ jobs:
           rm -Rf ./source/
           cd ./docs/
           ls -lart
-          # delete all top level folders that isn't reports 
+          # delete all top level folders except for documentation
           find . -type d -maxdepth 1 ! -path "." ! -path ".." ! -path "./documentation" | while read thisdir; do
-            echo -e "dir: ${thisdir}"            
+            echo -e "deleting dir: ${thisdir}"  
+            rm -Rf ${thisdir}          
+          done
+          # delete all top level files
+          find . -type f -maxdepth 1 ! -path "." ! -path ".." ! -path "./documentation" | while read thisfile; do
+            echo -e "deleting file: ${thisfile}"  
+            # rm -Rf ${thisdir}          
           done
           
           ls -lart

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -60,16 +60,14 @@ jobs:
           mv ./docs ../
       - name: "Checkout to gh-pages and move built files back"
         env:
-          reports_root: "documention"
         run: |
           git checkout -f gh-pages                    
           rm -Rf ./source/
           cd ./docs/
           ls -lart
           # delete all top level folders that isn't reports 
-          find . -type d -maxdepth 1 -not -path ./${{ env.reports_root }}/* | while read thisdir; do
-            echo -e "dir: ${thisdir}"
-            
+          find . -type d -maxdepth 1 ! -path "." ! -path ".." ! -path "./documentation" | while read thisdir; do
+            echo -e "dir: ${thisdir}"            
           done
           
           ls -lart

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -65,7 +65,7 @@ jobs:
           git checkout -f gh-pages
           rm -Rf ./source/          
           find ./docs -type d ! -name "${{ env.exclude_from_docs_delete }}" -delete
-          cp -RF ../docs/ ./          
+          cp -RT ../docs/ ./          
       - name: "Add version and CNAME file"
         run: |
           echo "${GITHUB_SHA}" > ./docs/version.txt

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -84,7 +84,9 @@ jobs:
       
       - name: "Move built files over"
         run : |          
+          ls -lartR ./docs/
           cp -RT ../docs/ ./          
+          ls -lartR ./docs/
       - name: "Add version and CNAME file"
         run: |
           echo "${GITHUB_SHA}" > ./docs/version.txt

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -69,7 +69,7 @@ jobs:
           # delete all top level folders that isn't reports 
           find . -type d -maxdepth 1 -not -path ./${{ env.reports_root }}/* | while read thisdir; do
             echo -e "dir: ${thisdir}"
-            rm -Rf ./${thisdir}
+            
           done
           
           ls -lart

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -83,9 +83,11 @@ jobs:
 
       
       - name: "Move built files over"
-        run : |          
+        run : |  
+          echo -e "Current:"        
           ls -lartR ./docs/
-          cp -RT ../docs/ ./          
+          cp -RT ../docs ./        
+          echo -e "After:"          
           ls -lartR ./docs/
       - name: "Add version and CNAME file"
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -65,11 +65,14 @@ jobs:
           git checkout -f gh-pages                    
           rm -Rf ./source/
           cd ./docs
-          pwd
-          ls -lart
-          find . -type d ! -name "${{ env.exclude_from_docs_delete }}" -exec rm -rf "{}" \;
-          ls -lart
+          find . -type d | while read -r i; do
+            echo -e "${i}";
+            if [ "${i}" != "${{ env.exclude_from_docs_delete}}" ]; then
+              echo -e "delete... "
+            fi
+          done
           cd ../
+
           cp -RT ../docs/ ./          
       - name: "Add version and CNAME file"
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -64,7 +64,7 @@ jobs:
         run: |
           git checkout -f gh-pages
           rm -Rf ./source/          
-          find ./docs -type d ! -name "${{ env.exclude_from_docs_delete }}" -delete
+          find ./docs -type d ! -name "${{ env.exclude_from_docs_delete }}" -exec rm -rf "{}" \;
           cp -RT ../docs/ ./          
       - name: "Add version and CNAME file"
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -65,25 +65,20 @@ jobs:
           git clean -fd
       - name: "Move gh folder back"
         run: mv ../.github ./
-      - name: "Remove top level directories and files from ./docs"
+      - name: "Remove top level directories and files from ./docs, excluding ./documentation"
         uses: './.github/actions/find-delete'
         with:
           base_dir: ${{ github.workspace }}/docs
           exclude: './documentation'
           type: 'directory file'
-      
-      # - name: "Remove other directories from ./docs/documentation, leaving ./reports/ only"
-      #   working-directory: ${{ github.workspace }}/docs/documentation
-      #   run: | 
-      #     echo -e "Before:"         
-      #     ls -lart
-      #     # delete all top level folders except for documentation
-      #     find . -type d -maxdepth 1 ! -path "." ! -path ".." ! -path "./reports" | while read thisdir; do
-      #       echo -e "deleting dir: ${thisdir}"  
-      #       #rm -Rf ${thisdir}          
-      #     done
-      #     echo -e "After:"         
-      #     ls -lart
+          confirm_delete: true
+      - name: "Remove other directories from ./docs/documentation, excluding ./reports"
+        uses: './.github/actions/find-delete'
+        with:
+          base_dir: ${{ github.workspace }}/docs/documentation
+          exclude: './reports/'
+          type: 'directory file'
+
       
       - name: "Move built files over"
         run : |          

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,12 +59,18 @@ jobs:
           make build
           mv ./docs ../
       - name: "Checkout to gh-pages and move built files back"
+        env:
+          reports_root: "documention"
         run: |
           git checkout -f gh-pages                    
           rm -Rf ./source/
           cd ./docs/
-          # delete all top level folders that isn't reports -exec rm -rf "{}" \;
-          find . -type d -maxdepth 1 ! -name "./documention/" -printf '%f\n'
+          ls -lart
+          # delete all top level folders that isn't reports 
+          find . -type d -maxdepth 1 ! -name "${{ env.reports_root }}" -not -path '.' | while read thisdir; do
+            echo -e "${thisdir}"
+            rm -Rf ./${thisdir}
+          done
           
           ls -lart
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,26 +58,31 @@ jobs:
         run: |
           make build
           mv ./docs ../
-      - name: "Checkout to gh-pages and move built files back"
-        run: |
-          git checkout -f gh-pages                    
-          rm -Rf ./source/
-          cd ./docs/
+      - name: "Checkout to gh-pages"
+        run: git checkout -f gh-pages                    
+      - name: "Remove ./source/"
+        run: rm -Rf ./source/
+      - name: "Remove top level directories from ./docs"
+        working-directory: ${{ github.workspace }}/docs
+        run: |          
           ls -lart
           # delete all top level folders except for documentation
           find . -type d -maxdepth 1 ! -path "." ! -path ".." ! -path "./documentation" | while read thisdir; do
             echo -e "deleting dir: ${thisdir}"  
             rm -Rf ${thisdir}          
           done
-          # delete all top level files
+          ls -lart
+      - name: "Remove top level files from ./docs"
+        working-directory: ${{ github.workspace }}/docs
+        run: |
+          ls -lart
           find . -type f -maxdepth 1 ! -path "." ! -path ".." ! -path "./documentation" | while read thisfile; do
             echo -e "deleting file: ${thisfile}"  
             # rm -Rf ${thisdir}          
           done
-          
           ls -lart
-
-          cd ../
+      - name: "Move built files over"
+        run : |          
           cp -RT ../docs/ ./          
       - name: "Add version and CNAME file"
         run: |

--- a/.github/workflows/reports-service-uptime.yml
+++ b/.github/workflows/reports-service-uptime.yml
@@ -1,9 +1,6 @@
 name: "[Reports] Service Uptime"
 
 on:
-  pull_request:
-    branches: 
-      - "main"
   schedule:
     - cron: '0 4 * * 0,2,4'
   workflow_dispatch:

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -59,8 +59,8 @@ New to the OPG team? [Read how to get started here](documentation/get_started)
 - [Releases Per Team and Month](documentation/reports/releases/by_team)
 - [Releases Per Repository and Month](documentation/reports/releases/by_repository)
 - [Respository Standards Compliance](documentation/reports/repository-standards/index)
+- [Service Uptime](documentation/reports/service-uptime/index)
 - *SBOM*
-- *Service Uptime*
 - *Team Metadata*
 
 


### PR DESCRIPTION
- Add a pr trigger for testing
- Update publishing workflow to include the new report
- Add a new local action to use find to remove folders / files with exclusions
- Change how hte publishing workflow handles the content of docs

As the workflow artifacts being used by service uptime have a 3 month uptime and the soruce data in aws also degrades granularity over time with a lifespan of around 3 months as well we want to keep the older reports present in version control. To keep the previous versions the doc generation / replacement has been updated to keep everything in the service-uptime folder that is present 

