### PR TITLE
Update domain naming standards link

### DIFF
--- a/source/documentation/adrs/adr-002.html.md.erb
+++ b/source/documentation/adrs/adr-002.html.md.erb
@@ -18,7 +18,7 @@ Establish a pattern for naming domains, currently we have a few variations acros
 
 ## Decision
 
-Reflect the [MoJ security guidance](https://security-guidance.service.justice.gov.uk/domain-names-policy/#standards-guidance-and-technology) and [MoJ naming standards](https://technical-guidance.service.justice.gov.uk/documentation/standards/naming-domains.html) where possible.
+Reflect the [MoJ security guidance](https://security-guidance.service.justice.gov.uk/domain-names-policy/#standards-guidance-and-technology) and [MoJ naming standards](https://user-guide.operations-engineering.service.justice.gov.uk/documentation/services/domain-naming-standard.html) where possible.
 
 ### Multiple Hosted Zones
 


### PR DESCRIPTION
## 👀 Purpose

- This PR updates the link to the new location for the MoJ Domain Naming Standard. All DNS related guidance is being co-located in the Operations Engineering User Guide.

## ♻️ What's changed

- Updated link to Domain Naming standard