### PR TITLE
Update OPG programming language guidance

### DIFF
--- a/source/documentation/guides/golang_advice.html.md.erb
+++ b/source/documentation/guides/golang_advice.html.md.erb
@@ -31,7 +31,7 @@ We often use these libraries in our Go applications:
 - [mockery](https://github.com/vektra/mockery) - Generates mocks for testing
 - [air](https://github.com/cosmtrek/air) - CLI package that automatically rebuilds and reloads Go apps with local changes
 - [delve](https://github.com/go-delve/delve) - Debugger for Go applications
-- [validator](github.com/go-playground/validator/v10) - Struct and field validation for Go applications
+- [validator](https://github.com/go-playground/validator) - Struct and field validation for Go applications
 - [sqlc](https://github.com/sqlc-dev/sqlc) - Generates type-safe Go code from SQL queries
 - [goose](https://github.com/pressly/goose) - Database migration tool for Go applications
 

--- a/source/documentation/guides/golang_advice.html.md.erb
+++ b/source/documentation/guides/golang_advice.html.md.erb
@@ -8,7 +8,7 @@ owner_slack: "#opg-developers"
 
 # <%= current_page.data.title %>
 
-We use Go (Golang) in a variety of services in OPG Digital and it is typically our first choice for new development due to its efficency and strong type safety.
+We use Go (Golang) in a variety of services in OPG Digital and it is typically our first choice for new development due to its efficiency and strong type safety.
 
 We do not have any preferred frameworks for Go applications: instead we mostly rely on the standard library wherever possible to reduce our dependency graph and keep code simple and consistent.
 
@@ -16,7 +16,7 @@ We do not have any preferred frameworks for Go applications: instead we mostly r
 
 We have many services built with Go, but here are a few repositories that provide a good range of examples of our usage.
 
-- [opg-sirius-supervision-workflow](https://github.com/ministryofjustice/opg-sirius-supervision-workflow) is a front-end service to provide Sirius users with a bespoke interface for managing Supervision cases
+- [opg-sirius-supervision-finance-hub](https://github.com/ministryofjustice/opg-sirius-supervision-finance-hub) is a full-stack service built with Go to process payments and allow Supervision Billing to manage accounts for clients
 - [opg-modernising-lpa](https://github.com/ministryofjustice/opg-modernising-lpa) is the new Make and Register service built entirely in Go
 - [opg-data-lpa-store](https://github.com/ministryofjustice/opg-data-lpa-store) is a API for storing and accessing Digital LPAs built with Go-based Lambdas
 
@@ -30,6 +30,14 @@ We often use these libraries in our Go applications:
 - [testify](https://github.com/stretchr/testify) - Unit testing toolkit providing mock and assertion functions
 - [mockery](https://github.com/vektra/mockery) - Generates mocks for testing
 - [air](https://github.com/cosmtrek/air) - CLI package that automatically rebuilds and reloads Go apps with local changes
+- [delve](https://github.com/go-delve/delve) - Debugger for Go applications
+- [validator](github.com/go-playground/validator/v10) - Struct and field validation for Go applications
+- [sqlc](https://github.com/sqlc-dev/sqlc) - Generates type-safe Go code from SQL queries
+- [goose](https://github.com/pressly/goose) - Database migration tool for Go applications
+
+## UI
+
+Our Go applications typically use Go [templates](https://pkg.go.dev/html/template) for rendering HTML, with small JS scripts for interactivity. For conditional rendering of the DOM, we have had success with [HTMX](https://htmx.org/) (see finance-hub for examples).
 
 ## Learning Resources
 

--- a/source/documentation/guides/golang_advice.html.md.erb
+++ b/source/documentation/guides/golang_advice.html.md.erb
@@ -1,57 +1,39 @@
 ---
-title: Golang Patterns and Approaches
+title: Go Language
 weight: 10
-last_reviewed_on: 2024-06-26
+last_reviewed_on: 2026-06-26
 review_in: 12 months
 owner_slack: "#opg-developers"
 ---
 
 # <%= current_page.data.title %>
 
-We initially trialled golang on a number of smaller services and tools (Sirius User Admin, ECS stabiliser). We've since started rolling it out in other services (Supervision Workflow, Search Service). Now we have a bit more experience working with the language. It's worth documenting our preferred approaches, tools and libraries for doing so. This will help future developers get up to speed on our services more easily and set some expectations for team members to reference when starting new work.
+We use Go (Golang) in a variety of services in OPG Digital and it is typically our first choice for new development due to its efficency and strong type safety.
 
-## Why Golang?
+We do not have any preferred frameworks for Go applications: instead we mostly rely on the standard library wherever possible to reduce our dependency graph and keep code simple and consistent.
 
-We chose to adopt golang as a secondary language within OPG Digital because:
+## Example OPG Go repositories
 
-- Modern language
-- Small ecosystem
-- Web features as first class citizens
-- Performant and produces small containers
-- Aligned to infrastructure tooling languages
+We have many services built with Go, but here are a few repositories that provide a good range of examples of our usage.
 
-## Prefered Tools & Libraries
+- [opg-sirius-supervision-workflow](https://github.com/ministryofjustice/opg-sirius-supervision-workflow) is a front-end service to provide Sirius users with a bespoke interface for managing Supervision cases
+- [opg-modernising-lpa](https://github.com/ministryofjustice/opg-modernising-lpa) is the new Make and Register service built entirely in Go
+- [opg-data-lpa-store](https://github.com/ministryofjustice/opg-data-lpa-store) is a API for storing and accessing Digital LPAs built with Go-based Lambdas
 
-- [golangci-lint](https://github.com/golangci/golangci-lint) - Fast golang linter for checking code style in CI or locally. This bundles lots of the other linters in the golang ecosystem including gosec to check for potential security issues. Install it to your local machine with brew install golangci-lint
-- [testify](https://github.com/stretchr/testify) - Testing tools, including more readable assertions and mocking tools.
-- [aws-sdk-go-v2](https://github.com/aws/aws-sdk-go-v2) - AWS SDK for golang. Because we use lots of AWS. Make sure you move to v2.
-- [air](https://github.com/cosmtrek/air) - Allows hot reloading during development so you don’t need to manually recompile on changes.
-- [zap](go.uber.org/zap) - A nice structured logging library for JSON output
+[All OPG repos using Go](https://github.com/orgs/ministryofjustice/repositories?q=language%3AGo+opg)
 
-## Tools useful in services
+## Standard tools
 
-- [aws-secretsmanager-caching-go](https://github.com/aws/aws-secretsmanager-caching-go) - Caching secrets in memory and calling for new ones if they fail rather than using environment vars.
-- [jwt-go](https://github.com/dgrijalva/jwt-go) - JWT implementation for go, useful for talking to Sirius APIs.
-- [objx](https://github.com/stretchr/objx) - Useful tools for dealing with JSON and maps.
-- [go-spew](https://github.com/davecgh/go-spew) - A nicer pretty printer for development/debugging.
+We often use these libraries in our Go applications:
 
-Note we previously recommended [gorilla/mux](https://github.com/gorilla/mux), but that set of libraries had maintenence issues and since that time the core HTTP router has evolved to cover most uses cases. Use the internal HTTP router unless you have a very odd edge case, see the [golang 1.22](https://go.dev/blog/routing-enhancements) release notes.
-
-## Preferred Patterns
-
-[Uber-go](https://github.com/uber-go/guide/blob/master/style.md) - Go has a very good built-in formatter for writing correct Go. This Uber style README.md covers extra stylistic concerns not covered by Go's standard practices. For example the Verifying Interface Compliance
-
-Generally our golang services are microservices and micro-frontends. This allows us to build small, isolated components focused on a particular domain that can be deployed independently. One repo per service.
-
-Our normal coding standards and repo principles still apply.
-
-[go:embed](https://blog.carlmjohnson.net/post/2021/how-to-use-go-embed/) annotations are useful for bundling templates
-
-Our micro-frontends currently use [cypress](https://www.cypress.io/) for end-to-end testing. We are begining the move to PlayWright to replace Cypress.
-
-We recommend you add in pre-commit hooks to your repo. Precommits should be pinned to a known good SHA.
+- [golangci-lint](https://github.com/golangci/golangci-lint) - Go linter that bundles multiple other linting tools
+- [testify](https://github.com/stretchr/testify) - Unit testing toolkit providing mock and assertion functions
+- [mockery](https://github.com/vektra/mockery) - Generates mocks for testing
+- [air](https://github.com/cosmtrek/air) - CLI package that automatically rebuilds and reloads Go apps with local changes
 
 ## Learning Resources
+
+These are resources we've found useful in OPG for learning and mastering Go.
 
 - <https://tour.golang.org/> - The official Golang tour for learning Go. Very informative
 - <https://gobyexample.com> - Introductory site that explains with clear examples.
@@ -61,7 +43,7 @@ We recommend you add in pre-commit hooks to your repo. Precommits should be pinn
 - <https://medium.com/wesionary-team/pointers-and-passby-value-reference-in-golang-a00c8c59b7f1> - understanding Pointers and Values
 - <https://github.com/dariubs/GoBooks> - GitHub repo with a list of a bunch of books which you may find useful
 
-## Video Courses
+### Video Courses
 
 Ask your line manager about a Pluralsight license.
 

--- a/source/documentation/guides/php.html.md.erb
+++ b/source/documentation/guides/php.html.md.erb
@@ -1,0 +1,24 @@
+---
+title: PHP Language
+weight: 10
+last_reviewed_on: 2026-06-26
+review_in: 12 months
+owner_slack: "#opg-developers"
+---
+
+# <%= current_page.data.title %>
+
+We use PHP in OPG services for many years, and it forms the backbone of many of our core services. We favour PHP for its flexibility, long-term support and rich ecosystem.
+
+We have used a variety of PHP frameworks, but most services now either use [Mezzio](https://docs.mezzio.dev/).
+
+## Example OPG PHP repositories
+
+Most of our larger applications use PHP:
+
+- [opg-lpa](https://github.com/ministryofjustice/opg-lpa),  Make a lasting power of attorney
+- [opg-use-an-lpa](https://github.com/ministryofjustice/opg-use-an-lpa),  Use a lasting power of attorney
+- [opg-digideps](https://github.com/ministryofjustice/opg-digideps), Complete the deputy report
+- [opg-sirius](https://github.com/ministryofjustice/opg-sirius), Sirius
+
+[All Ministry of Justice repos using PHP](https://github.com/orgs/ministryofjustice/repositories?q=language%3APHP+opg)

--- a/source/documentation/guides/php.html.md.erb
+++ b/source/documentation/guides/php.html.md.erb
@@ -10,7 +10,7 @@ owner_slack: "#opg-developers"
 
 We use PHP in OPG services for many years, and it forms the backbone of many of our core services. We favour PHP for its flexibility, long-term support and rich ecosystem.
 
-We have used a variety of PHP frameworks, but most services now either use [Mezzio](https://docs.mezzio.dev/).
+We have used a variety of PHP frameworks, but most services now predominantly use [Mezzio](https://docs.mezzio.dev/).
 
 ## Example OPG PHP repositories
 
@@ -18,7 +18,7 @@ Most of our larger applications use PHP:
 
 - [opg-lpa](https://github.com/ministryofjustice/opg-lpa),  Make a lasting power of attorney
 - [opg-use-an-lpa](https://github.com/ministryofjustice/opg-use-an-lpa),  Use a lasting power of attorney
-- [opg-digideps](https://github.com/ministryofjustice/opg-digideps), Complete the deputy report
+- [opg-digideps](https://github.com/ministryofjustice/opg-digideps), Complete the deputy report — uses [Symfony](https://symfony.com/) as a framework
 - [opg-sirius](https://github.com/ministryofjustice/opg-sirius), Sirius
 
 [All Ministry of Justice repos using PHP](https://github.com/orgs/ministryofjustice/repositories?q=language%3APHP+opg)

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -30,10 +30,14 @@ New to the OPG team? [Read how to get started here](documentation/get_started)
 - [Baseline Testing Standards](documentation/guides/baseline_testing_standards)
 - [AWS Root Account Access](documentation/guides/aws_root_access)
 - [GitHub Copilot Access](documentation/guides/github_copilot_access)
-- [Golang Advice](documentation/guides/golang_advice)
 - [API Standards](documentation/guides/api_standards)
 - [Choosing Dependencies](documentation/guides/dependencies)
 - [Joiners/Movers/Leavers](documentation/guides/joiners_movers_leavers)
+
+### Languages and tools
+
+- [Go](documentation/guides/golang_advice)
+- [PHP](documentation/guides/php)
 
 ## Communites of practice
 


### PR DESCRIPTION
- Simplify intro text about Go
- Link to example repositories
- Reduce list of packages to ones we still use
- Add a similar page about PHP

#minor