### PR TITLE
Add guidance to incident response process criteria

### DIFF
--- a/source/documentation/incidents/process.html.md.erb
+++ b/source/documentation/incidents/process.html.md.erb
@@ -10,6 +10,8 @@ This document describes our incident handling process (inspired by work elsewher
 
 ## Confirm that an event constitutes an incident
 
+**If you're in doubt**, declare an incident anyway. We can stop the incident process at any point if we decide to de-escalate, and it helps to centralise the conversation.
+
 We define an incident as an event which:
 
 * Requires immediate response to return normal service


### PR DESCRIPTION
Add a paragraph encouraging the declaration of an incident, to avoid confusion over how events are being handled.